### PR TITLE
Fix missing `project_name` in `setup.py`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/rename_project.yml
+++ b/.github/workflows/rename_project.yml
@@ -7,7 +7,7 @@ jobs:
     if: ${{ github.repository	!= 'ICRAR/daliuge-component-template' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # by default, it uses a depth of 1
           # this fetches all history so that we can read each commit
@@ -25,15 +25,16 @@ jobs:
         
       - name: Is this still a template
         id: is_template
-        run: echo "::set-output name=is_template::$(ls .github/template.yml &> /dev/null && echo true || echo false)"
+        run: |
+          echo "is_template=$(ls .github/template.yml &> /dev/null && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Rename the project
         if: steps.is_template.outputs.is_template == 'true'
         run: |
           echo "Renaming the project with -a(author) ${{ env.REPOSITORY_OWNER }} -n(name) ${{ env.REPOSITORY_NAME }} -u(urlname) ${{ env.REPOSITORY_URLNAME }}"
           .github/rename_project.sh -a ${{ env.REPOSITORY_OWNER }} -n ${{ env.REPOSITORY_NAME }} -u ${{ env.REPOSITORY_URLNAME }} -d "Awesome ${{ env.REPOSITORY_NAME }} created by ${{ env.REPOSITORY_OWNER }}"
-              
-      - uses: stefanzweifel/git-auto-commit-action@v4
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "✅ Ready to clone and code."
           # commit_options: '--amend --no-edit'

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,7 @@ setup(
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     author="author_name",
-    package_dir={"":"project_name"},
-    packages=find_packages(where="project_name",exclude=["tests", ".github"]),
+    packages=find_packages(exclude=["tests", ".github"]),
     install_requires=read_requirements("requirements.txt"),
     entry_points={
         "console_scripts": ["project_name = project_name.__main__:main"]

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ setup(
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     author="author_name",
-    package_dir={"":"src"},
-    packages=find_packages(where="src",exclude=["tests", ".github"]),
+    package_dir={"":"project_name"},
+    packages=find_packages(where="project_name",exclude=["tests", ".github"]),
     install_requires=read_requirements("requirements.txt"),
     entry_points={
         "console_scripts": ["project_name = project_name.__main__:main"]


### PR DESCRIPTION
In #1, I missed updating the src/ directory to be `project_name`. This caused errors when trying to build/install a newly created repository based on this template, as it was trying to build from `src` instead of `project_name`. 

I have now updated that as part of this PR.

## Summary by Sourcery

Enhancements:
- Update package directory references from 'src' to 'project_name' in setup configuration.